### PR TITLE
meson: Fix library dir path

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -32,5 +32,5 @@ shared_library('gnome-mutter-screencast',
     dependency('gdk-3.0'),
   ],
   install : true,
-  install_dir : 'lib/obs-plugins'
+  install_dir : get_option('libdir') + '/obs-plugins'
 )


### PR DESCRIPTION
I am trying to create an rpm package for this.
Use the library dir provided by the system rather than hardcoded /lib/
because some OS might use different paths (eg Fedora uses /lib64/ by
default).