### PR TITLE
Fix double unref

### DIFF
--- a/gnome-mutter-screencast.c
+++ b/gnome-mutter-screencast.c
@@ -515,8 +515,10 @@ fail:
 	if (stream_res != NULL)
 		g_variant_unref(stream_res);
 
-	if (dbus != NULL)
+	if (dbus != NULL) {
 		g_object_unref(dbus);
+		dbus = NULL;
+	}
 
 	GSource *source = g_idle_source_new();
 	g_source_set_callback(source, loop_startup, data, NULL);


### PR DESCRIPTION
The variable `dbus` is set twice and unref'd twice throughout the course of `_start`, however there's a `goto` that may skip the second set without skipping the second unref. Since the first unref doesn't set `dbus` to `NULL`, the second unref will attempt to unref the already unref'd pointer. This appears to result in Mutter (or something else along the chain) simply giving up and refusing to record any subsequent windows until OBS is restarted.

This bug can be recreated by closing a window while the plugin settings are open (so that the list of windows doesn't have a chance to update), selecting the now-closed window in the list (resulting in a black screen/no capture), and then trying to set any subsequent window (which will continue to be a black screen until OBS is restarted).

Tested on GNOME 40.5 on Arch.